### PR TITLE
Modified the anonymous type check to include array elements and type parameters.

### DIFF
--- a/VarReplacer/VarReplacer/ITypeSymbolExtensions.cs
+++ b/VarReplacer/VarReplacer/ITypeSymbolExtensions.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Microsoft.CodeAnalysis;
+
+namespace VarReplacer
+{
+    internal static class ITypeSymbolExtensions
+    {
+        public static bool HasAnonymousType(this ITypeSymbol realType)
+        {
+            if (realType == null)
+                return false;
+
+            if (realType.IsAnonymousType)
+                return true;
+
+            IArrayTypeSymbol arrayType = realType as IArrayTypeSymbol;
+            if (arrayType != null && HasAnonymousType(arrayType.ElementType))
+                return true;
+
+            INamedTypeSymbol namedType = realType as INamedTypeSymbol;
+            if (namedType != null)
+            {
+                if (namedType.IsGenericType)
+                {
+                    foreach (ITypeSymbol argument in namedType.TypeArguments)
+                    {
+                        if (HasAnonymousType(argument as INamedTypeSymbol))
+                            return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/VarReplacer/VarReplacer/VarReplacer.csproj
+++ b/VarReplacer/VarReplacer/VarReplacer.csproj
@@ -31,6 +31,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="ITypeSymbolExtensions.cs" />
     <Compile Include="VarReplacerCodeFixProvider.cs" />
     <Compile Include="VarReplacerAnalyzer.cs" />
     <Compile Include="AssemblyInfo.cs" />

--- a/VarReplacer/VarReplacer/VarReplacerAnalyzer.cs
+++ b/VarReplacer/VarReplacer/VarReplacerAnalyzer.cs
@@ -78,7 +78,7 @@ namespace VarReplacer
 
         private static void CheckVar(SyntaxNodeAnalysisContext context, ITypeSymbol realType, Location varLocation)
         {
-            if (realType != null && !realType.IsAnonymousType && !context.CancellationToken.IsCancellationRequested)
+            if (realType != null && !realType.HasAnonymousType() && !context.CancellationToken.IsCancellationRequested)
             {
                 string realName = realType.ToMinimalDisplayString(context.SemanticModel, varLocation.SourceSpan.Start);
                 IDictionary<string, string> props = new Dictionary<string, string>


### PR DESCRIPTION
I was getting IEnumerable<<anonymous type: ...>> from LINQ expressions that projected anonymous types.  I think (hope) this pull request will prevent the refactoring from being presented anywhere that an anonymous type is involved.
